### PR TITLE
small changes to base class to better support generic cip drivers

### DIFF
--- a/pycomm/cip/cip_base.py
+++ b/pycomm/cip/cip_base.py
@@ -847,9 +847,6 @@ class Base(object):
                 if self.register_session() is None:
                     self._status = (13, "Session not registered")
                     return False
-
-                # not sure but maybe I can remove this because is used to clean up any previous unclosed connection
-                self.forward_close()
                 return True
             except Exception as e:
                 # self.clean_up()
@@ -882,22 +879,6 @@ class Base(object):
 
         if error_string:
             raise CommError(error_string)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     def clean_up(self):
         self.__sock = None

--- a/pycomm/cip/cip_const.py
+++ b/pycomm/cip/cip_const.py
@@ -177,6 +177,7 @@ SERVICE_STATUS = {
     0x13: "Insufficient command data",
     0x14: "Attribute not supported",
     0x15: "Too much data",
+    0x16: "Object does not exist",
     0x1A: "Bridge request too large",
     0x1B: "Bridge response too large",
     0x1C: "Attribute list shortage",


### PR DESCRIPTION
The extra forward_close call is an issue for generic cip messages, and by requesting an invalid path I found that the 0x16 status was absent (raised KeyError).