### PR TITLE
Fix read_array functionality in Python 3.5

### DIFF
--- a/pycomm/ab_comm/clx.py
+++ b/pycomm/ab_comm/clx.py
@@ -457,8 +457,8 @@ class Driver(Base):
                 # Creating the Message Request Packet
                 message_request = [
                     pack_uint(Base._get_sequence()),
-                    chr(TAG_SERVICES_REQUEST["Read Tag Fragmented"]),  # the Request Service
-                    chr(len(rp) / 2),                                  # the Request Path Size length in word
+                    byte([TAG_SERVICES_REQUEST["Read Tag Fragmented"]]),  # the Request Service
+                    byte([len(rp) // 2)],                                  # the Request Path Size length in word
                     rp,                                                # the request path
                     pack_uint(counts),
                     pack_dint(self._byte_offset)
@@ -467,7 +467,7 @@ class Driver(Base):
             if self.send_unit_data(
                     build_common_packet_format(
                         DATA_ITEM['Connected'],
-                        ''.join(message_request),
+                        b''.join(message_request),
                         ADDRESS_ITEM['Connection Based'],
                         addr_data=self._target_cid,
                     )) is None:


### PR DESCRIPTION
Limited testing shows this now works in python 3.5.3