### PR TITLE
Bandaid fix for exception error handling in python 3

### DIFF
--- a/pycomm/cip/cip_base.py
+++ b/pycomm/cip/cip_base.py
@@ -864,7 +864,7 @@ class Base(object):
             if self._session != 0:
                 self.un_register_session()
         except Exception as e:
-            error_string += "Error on close() -> session Err: %s" % e.message
+            error_string += "Error on close() -> session Err: %s" % e
             logger.warning(error_string)
 
         # %GLA must do a cleanup __sock.close()
@@ -872,7 +872,7 @@ class Base(object):
             if self.__sock:
                 self.__sock.close()
         except Exception as e:
-            error_string += "; close() -> __sock.close Err: %s" % e.message
+            error_string += "; close() -> __sock.close Err: %s" % e
             logger.warning(error_string)
 
         self.clean_up()


### PR DESCRIPTION
Exception handling has changed a bit in python 3. when using exception as E, it no longer has the attribute e.message. now the message string is fully in e.

This is a bandaid fix that I did when editing the file during error checking. It may not be the correct way to do it.

I saw this when I was forcibly disconnecting the script after a c.open was called. Here is the log bit that called out this section and caused my script to not auto reconnect.

```
     File "C:\Python36\lib\site-packages\pycomm\cip\cip_base.py", line 867, in close
    error_string += "Error on close() -> session Err: %s" % e.message
AttributeError: 'CommError' object has no attribute 'message'
```